### PR TITLE
Fix typos in FAQ and returns policy pages

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -272,7 +272,7 @@
             <div id="productCollapseSeven" class="accordion-collapse collapse" data-bs-parent="#productInfoAccordion">
                 <div class="accordion-body">
                     Not yet. We're working on some products which will include personalisation options, but they're a
-                    while off. For now, you'll have to stick with our boring old products that dont have your dog's
+                    while off. For now, you'll have to stick with our boring old products that don't have your dog's
                     middle name on them.
                 </div>
             </div>
@@ -359,7 +359,7 @@
             </h2>
             <div id="orderCollapseThree" class="accordion-collapse collapse" data-bs-parent="#orderInfoAccordion">
                 <div class="accordion-body">
-                    Not at the moment, we're more focused on building great products and an online prescense.
+                    Not at the moment, we're more focused on building great products and an online presence.
                 </div>
             </div>
         </div>
@@ -532,7 +532,7 @@
             <div id="privacyCollapseFour" class="accordion-collapse collapse" data-bs-parent="#privacyInfoAccordion">
                 <div class="accordion-body">
                     Nope! The way this site is set up, there's actually no way for me to track what you're clicking on.
-                    In the checkout, you might see Stripe reccomending you some similar products, but that info's not
+                    In the checkout, you might see Stripe recommending you some similar products, but that info's not
                     linked to you. If you place an order, I am able to see who placed it and what other orders they've
                     placed, but that's the only "tracking" we do.
                 </div>

--- a/returns-policy.html
+++ b/returns-policy.html
@@ -237,7 +237,7 @@
         be eligible for reimbursements. Ideally, use the original packaging.
     </p>
     <p>
-        If we determine your item is not eiligible for return, we will return it to you at your cost, or provide you
+        If we determine your item is not eligible for return, we will return it to you at your cost, or provide you
         with a partial Refund.
     </p>
 


### PR DESCRIPTION
Corrected several spelling errors in faq.html and returns-policy.html, including 'dont' to 'don't', 'prescense' to 'presence', 'reccomending' to 'recommending', and 'eiligible' to 'eligible'. See #14